### PR TITLE
Fix restarting behaviour by cleaning up those old listeners

### DIFF
--- a/game.js
+++ b/game.js
@@ -18,7 +18,7 @@ function startGame () {
     resetUi()
     inputElement.focus()
 
-    restartButtonElement.addEventListener('click', startGame)
+    restartButtonElement.addEventListener('click', restartGame)
 
     function resetUi () {
         messageElement.innerHTML = 'Welcome!'
@@ -58,10 +58,21 @@ function startGame () {
         maxRangeElement.innerHTML = maxRange
     }
 
-    formElement.addEventListener('submit', function (event) {
+    function restartGame () {
+        // clean up after ourselves
+        restartButtonElement.removeEventListener('click', restartGame);
+        formElement.removeEventListener('submit', submit);
+
+        // now we can start a new one and attach new listeners
+        startGame();
+    }
+    
+    function submit (event) {
         event.preventDefault()
         handleGuess()
-    })
+    }
+
+    formElement.addEventListener('submit', submit)
 
     /*
     inputElement.addEventListener('keyup', function (event) {


### PR DESCRIPTION
Při inicializaci nové hry je potřeba zahodit staré `click` a `submit` listenery, jinak nám "sahají pod ruce" a hra nefunguje.

Na to je metoda `removeEventListener`, která očekává dva argumenty: **event name** a **původní callback** který chceme odebrat. Proto na řádku 70 vytváříme NEanonymní funkci `function submit` z původně anonymního callbacku který je vidět v předchozí verzi na řádku 61. A to samé děláme pro `restartGame` funkci, kterou navíc obohatíme o koště a zameteme po sobě odebráním těch původních callbacků pomocí `removeEventListener`.